### PR TITLE
docs(gradle): add README usage and Jenkins build step (PR-C of #69)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,6 +92,19 @@ spec:
         }
       }
     }
+
+    stage('Gradle Build') {
+      steps {
+        dir('gradle') {
+          sh './gradlew build'
+        }
+      }
+      post {
+        always {
+          junit allowEmptyResults: true, testResults: 'gradle/build/test-results/test/**/*.xml'
+        }
+      }
+    }
   }
 
   post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,8 @@ spec:
     stage('Gradle Build') {
       steps {
         dir('gradle') {
-          sh './gradlew build'
+          // --no-daemon: short-lived CI pod throws the daemon away, no point paying startup
+          sh './gradlew build --no-daemon'
         }
       }
       post {

--- a/README.md
+++ b/README.md
@@ -131,3 +131,90 @@ You can further customize the extension with the following properties:
   </properties>
 </pluginExtension>
 ```
+
+## Usage with Gradle
+
+To use the Jib JVM Flags extension in your project, configure `jib-gradle-plugin` as follows:
+
+```gradle
+// should be at the top of build.gradle
+buildscript {
+  dependencies {
+    classpath 'tw.com.softleader.cloud.tools:jib-jvm-flags-extension-gradle:<VERSION>'
+  }
+}
+
+jib {
+  pluginExtensions {
+    pluginExtension {
+      implementation = 'tw.com.softleader.cloud.tools.jib.gradle.JvmFlagsExtension'
+    }
+  }
+}
+```
+
+> **Note:** Compatible with `jib-gradle-plugin` 3.4.x / 3.5.x.
+
+### Customizing Entrypoint with Java Command (Gradle)
+
+To customize the entrypoint using a direct Java command, for example:
+
+```gradle
+jib {
+  container {
+    jvmFlags = ['-XshowSettings:vm', '-Xdebug']
+    entrypoint = ['java', '@/app/jib-jvm-flags-file', '-cp', '@/app/jib-classpath-file', '@/app/jib-main-class-file']
+  }
+  pluginExtensions {
+    pluginExtension {
+      implementation = 'tw.com.softleader.cloud.tools.jib.gradle.JvmFlagsExtension'
+    }
+  }
+}
+```
+
+### Customizing Entrypoint Using a Shell Script (Gradle)
+
+Reuse the shell script shown in the Maven example above, then configure the plugin to invoke it:
+
+```gradle
+jib {
+  container {
+    jvmFlags = ['-XshowSettings:vm', '-Xdebug']
+    entrypoint = ['sh', '/entrypoint.sh']
+  }
+  extraDirectories {
+    paths {
+      path {
+        from = '.'
+        includes = ['entrypoint.sh']
+      }
+    }
+  }
+  pluginExtensions {
+    pluginExtension {
+      implementation = 'tw.com.softleader.cloud.tools.jib.gradle.JvmFlagsExtension'
+    }
+  }
+}
+```
+
+### Extension Properties (Gradle)
+
+You can further customize the extension with the following properties:
+
+```gradle
+pluginExtension {
+  implementation = 'tw.com.softleader.cloud.tools.jib.gradle.JvmFlagsExtension'
+  properties = [
+    // Skip if no jvmFlags specified, Default: false
+    skipIfEmpty: 'true',
+    // The separator character to use to join jvmFlags, Default: " " (space)
+    separator: ',',
+    // Set the output file name in container, Default: jib-jvm-flags-file
+    filename: 'my-jvm-flags-file',
+    // Set the output file permissions in container, Default: 644
+    mode: '666'
+  ]
+}
+```


### PR DESCRIPTION
## Summary

- Add `## Usage with Gradle` section to README mirroring the Maven section: buildscript classpath, `jib { pluginExtensions { ... } }` DSL, two entrypoint customization examples, four extension properties, and a jib-gradle-plugin 3.4.x / 3.5.x compatibility note. Existing Maven section is unchanged.
- Add a `Gradle Build` stage to `Jenkinsfile` that runs `./gradlew build` from `gradle/` after the Maven stages and publishes its JUnit XML reports.

Covers the README half of MVP-7 and the Jenkinsfile half of MVP-5 from the [spec](docs/specs/2026-05-monorepo-and-gradle.md). Release pipeline migration (release-please v2 + maven-publish for the gradle module) lands in PR-D.

## Test plan

- [x] `(cd gradle && ./gradlew build)` green locally on JDK 11
- [x] Confirmed `gradle/build/test-results/test/TEST-*.xml` exists, matching the Jenkinsfile junit glob
- [x] README diff renders correctly (parallel sub-section structure with Maven, code blocks tagged with \`gradle\` lang)
- [ ] Jenkins build of this branch goes green end-to-end (Confirm Env → Compile/Style Check → Unit Testing → Gradle Build)