### PR TITLE
fix(release): skip default deploy on aggregator parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,14 @@
   <profiles>
     <profile>
       <id>release</id>
+      <properties>
+        <!-- The aggregator pom is not published. Without distributionManagement,
+             the default maven-deploy-plugin:deploy on the aggregator would fail;
+             skipping it lets the reactor reach the publishable maven module.
+             The maven module's central-publishing extension replaces the default
+             deploy goal, so this property has no effect there. -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+      </properties>
       <build>
         <pluginManagement>
           <plugins>
@@ -271,10 +279,7 @@
               </executions>
             </plugin>
             <plugin>
-              <!-- https://central.sonatype.org/publish/publish-portal-maven/
-                   Declared here so only modules that opt in (the publishable
-                   ones) load it as an extension; the aggregator parent does
-                   not publish. -->
+              <!-- https://central.sonatype.org/publish/publish-portal-maven/ -->
               <groupId>org.sonatype.central</groupId>
               <artifactId>central-publishing-maven-plugin</artifactId>
               <version>${central-publishing-maven-plugin.version}</version>


### PR DESCRIPTION
## Summary

- Build #8 of \`jib-jvm-flags-extension-maven-release\` failed with \`Deployment failed: repository element was not specified in the POM inside distributionManagement element\`. After PR #76 moved \`central-publishing-maven-plugin\` into \`<pluginManagement>\`, the aggregator parent stopped loading the build extension, so its deploy phase fell back to the default \`maven-deploy-plugin:deploy\` — which has no \`<distributionManagement>\` and aborts the reactor.
- A reactor-mode spike showed that re-loading the extension on the aggregator with \`skipPublishing=true\` does NOT prevent the parent pom from being staged when sibling modules are present (central-publishing 0.8.0 collects deferred artifacts reactor-wide). So that direction won't work.
- Set \`maven.deploy.skip=true\` in the release profile. Aggregator's \`default-deploy\` short-circuits; maven module's \`central-publishing\` extension replaces default deploy, so the property is a no-op there.

## Test plan

- [x] \`mvn -P release -pl maven -am deploy -DskipTests -Dgpg.skip=true -DaltDeploymentRepository=fake::file:///tmp/fake-repo\` shows aggregator: \`Skipping artifact deployment\`; maven module: \`central-publishing:publish\` stages 4 artifacts (jar, flattened pom, sources, javadoc) to \`maven/target/central-deferred/\` — root pom not staged
- [ ] After merge, release-please opens 1.1.2 release PR; merging it triggers Jenkins job which should reach Sonatype validation and accept the bundle (will contain only maven module artifacts, all signed)